### PR TITLE
CheckKoeri geändert zu checkori

### DIFF
--- a/commands/checkKoeri.js
+++ b/commands/checkKoeri.js
@@ -4,7 +4,7 @@ const { checkKoeri } = require("../utils/checkKoeriAvailibility");
 
 module.exports = {
 	data: new SlashCommandBuilder()
-		.setName('checkKoeri')
+		.setName('checkoeri')
 		.setDescription('Check if Koeriwerk is open'),
 	async execute(interaction) {
         if(!checkKoeri()){


### PR DESCRIPTION
Weil Discord keine Großbuchstaben in seinen Befehlen haben WILL.
Böses Discord.
Gehört geschlagen...